### PR TITLE
Add glyph bhook for U+0253 “Latin small letter b with hook”

### DIFF
--- a/src/Masters/Raleway-Black.ufo/glyphs/bhook.glif
+++ b/src/Masters/Raleway-Black.ufo/glyphs/bhook.glif
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bhook" format="1">
+  <advance width="600"/>
+  <unicode hex="0253"/>
+  <outline>
+    <contour>
+      <point x="523" y="-10"/>
+      <point x="627" y="105"/>
+      <point x="627" y="261" type="curve" smooth="yes"/>
+      <point x="627" y="419"/>
+      <point x="531" y="536"/>
+      <point x="402" y="536" type="curve" smooth="yes"/>
+      <point x="326" y="536"/>
+      <point x="268" y="505"/>
+      <point x="238" y="448" type="curve"/>
+      <point x="238" y="529" type="line" smooth="yes"/>
+      <point x="238" y="563"/>
+      <point x="253" y="580"/>
+      <point x="284" y="580" type="curve" smooth="yes"/>
+      <point x="304" y="580"/>
+      <point x="333" y="574"/>
+      <point x="355" y="566" type="curve"/>
+      <point x="387" y="710" type="line"/>
+      <point x="334" y="730"/>
+      <point x="286" y="740"/>
+      <point x="241" y="740" type="curve" smooth="yes"/>
+      <point x="125" y="740"/>
+      <point x="48" y="654"/>
+      <point x="48" y="522" type="curve" smooth="yes"/>
+      <point x="48" y="0" type="line"/>
+      <point x="213" y="0" type="line"/>
+      <point x="213" y="82" type="line"/>
+      <point x="246" y="22"/>
+      <point x="304" y="-10"/>
+      <point x="383" y="-10" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="292" y="150"/>
+      <point x="263" y="168"/>
+      <point x="238" y="204" type="curve"/>
+      <point x="238" y="298" type="line"/>
+      <point x="256" y="344"/>
+      <point x="296" y="376"/>
+      <point x="336" y="376" type="curve" smooth="yes"/>
+      <point x="391" y="376"/>
+      <point x="432" y="324"/>
+      <point x="432" y="260" type="curve" smooth="yes"/>
+      <point x="432" y="194"/>
+      <point x="390" y="150"/>
+      <point x="328" y="150" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="329" y="708" type="move" name="top"/>
+    </contour>
+    <contour>
+      <point x="329" y="0" type="move" name="bottom"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/Masters/Raleway-Medium.ufo/glyphs/bhook.glif
+++ b/src/Masters/Raleway-Medium.ufo/glyphs/bhook.glif
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bhook" format="1">
+  <advance width="623"/>
+  <unicode hex="0253"/>
+  <outline>
+    <contour>
+      <point x="479" y="-10"/>
+      <point x="586" y="112"/>
+      <point x="586" y="259" type="curve" smooth="yes"/>
+      <point x="586" y="399"/>
+      <point x="495" y="531"/>
+      <point x="352" y="531" type="curve" smooth="yes"/>
+      <point x="267" y="531"/>
+      <point x="203" y="486"/>
+      <point x="159" y="418" type="curve"/>
+      <point x="159" y="536" type="line" smooth="yes"/>
+      <point x="159" y="619"/>
+      <point x="191" y="665"/>
+      <point x="249" y="665" type="curve" smooth="yes"/>
+      <point x="275" y="665"/>
+      <point x="305" y="656"/>
+      <point x="324" y="643" type="curve"/>
+      <point x="346" y="708" type="line"/>
+      <point x="314" y="728"/>
+      <point x="272" y="740"/>
+      <point x="231" y="740" type="curve" smooth="yes"/>
+      <point x="133" y="740"/>
+      <point x="71" y="661"/>
+      <point x="71" y="533" type="curve" smooth="yes"/>
+      <point x="71" y="0" type="line"/>
+      <point x="149" y="0" type="line"/>
+      <point x="149" y="98" type="line"/>
+      <point x="187" y="34"/>
+      <point x="258" y="-10"/>
+      <point x="339" y="-10" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="254" y="66"/>
+      <point x="172" y="116"/>
+      <point x="159" y="182" type="curve"/>
+      <point x="159" y="333" type="line"/>
+      <point x="190" y="399"/>
+      <point x="250" y="455"/>
+      <point x="325" y="455" type="curve" smooth="yes"/>
+      <point x="426" y="455"/>
+      <point x="496" y="361"/>
+      <point x="496" y="259" type="curve" smooth="yes"/>
+      <point x="496" y="159"/>
+      <point x="422" y="66"/>
+      <point x="317" y="66" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="339" y="708" type="move" name="top"/>
+    </contour>
+    <contour>
+      <point x="339" y="0" type="move" name="bottom"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/Masters/Raleway-Thin.ufo/glyphs/bhook.glif
+++ b/src/Masters/Raleway-Thin.ufo/glyphs/bhook.glif
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bhook" format="1">
+  <advance width="603"/>
+  <unicode hex="0253"/>
+  <outline>
+    <contour>
+      <point x="226" y="10"/>
+      <point x="109" y="82"/>
+      <point x="104" y="167" type="curve"/>
+      <point x="104" y="356" type="line"/>
+      <point x="143" y="435"/>
+      <point x="217" y="507"/>
+      <point x="316" y="507" type="curve" smooth="yes"/>
+      <point x="447" y="507"/>
+      <point x="537" y="386"/>
+      <point x="537" y="258" type="curve" smooth="yes"/>
+      <point x="537" y="135"/>
+      <point x="441" y="10"/>
+      <point x="307" y="10" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="448" y="-10"/>
+      <point x="557" y="117"/>
+      <point x="557" y="258" type="curve" smooth="yes"/>
+      <point x="557" y="386"/>
+      <point x="468" y="527"/>
+      <point x="316" y="527" type="curve" smooth="yes"/>
+      <point x="225" y="527"/>
+      <point x="157" y="473"/>
+      <point x="104" y="398" type="curve"/>
+      <point x="104" y="540" type="line" smooth="yes"/>
+      <point x="104" y="657"/>
+      <point x="146" y="721"/>
+      <point x="222" y="721" type="curve" smooth="yes"/>
+      <point x="253" y="721"/>
+      <point x="284" y="710"/>
+      <point x="300" y="694" type="curve"/>
+      <point x="316" y="706" type="line"/>
+      <point x="298" y="726"/>
+      <point x="259" y="740"/>
+      <point x="221" y="740" type="curve" smooth="yes"/>
+      <point x="135" y="740"/>
+      <point x="84" y="666"/>
+      <point x="84" y="540" type="curve" smooth="yes"/>
+      <point x="84" y="0" type="line"/>
+      <point x="104" y="0" type="line"/>
+      <point x="104" y="108" type="line"/>
+      <point x="145" y="42"/>
+      <point x="225" y="-10"/>
+      <point x="307" y="-10" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="307" y="708" type="move" name="top"/>
+    </contour>
+    <contour>
+      <point x="307" y="0" type="move" name="bottom"/>
+    </contour>
+  </outline>
+</glyph>


### PR DESCRIPTION
If this kind of submission works for you, I would send a series
of patches (or perhaps one big patch, as you prefer) for other
glyphs that would be useful for rendering phonetic (IPA) characters.

I’m assuming that the fonts in `src/Masters` are the actual masters
while the other UFO files in the repo are derived, but I’m not fully
sure about this.
